### PR TITLE
Do not hide exceptions

### DIFF
--- a/example.py
+++ b/example.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
 
     try:
         ta.is_genuine(opts)
-    except (TurboActivateConnectionDelayedError, TurboActivateConnectionError) as e:
+    except (TurboActivateConnectionDelayedError, TurboActivateConnectionError):
         print("YourApp is activated, but it failed to verify the activation with the LimeLM servers. "
               "You can still use the app for the duration of the grace period.")
     except TurboActivateError:

--- a/example.py
+++ b/example.py
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     try:
         ta.is_genuine(opts)
     except (TurboActivateConnectionDelayedError, TurboActivateConnectionError) as e:
-        print(
-            "YourApp is activated, but it failed to verify the activation with the LimeLM servers. You can still use the app for the duration of the grace period.")
+        print("YourApp is activated, but it failed to verify the activation with the LimeLM servers. "
+              "You can still use the app for the duration of the grace period.")
     except TurboActivateError:
         print("Not activated")
 

--- a/example.py
+++ b/example.py
@@ -45,8 +45,6 @@ if __name__ == "__main__":
     except (TurboActivateConnectionDelayedError, TurboActivateConnectionError) as e:
         print(
             "YourApp is activated, but it failed to verify the activation with the LimeLM servers. You can still use the app for the duration of the grace period.")
-
-        raise e
     except TurboActivateError:
         print("Not activated")
 

--- a/turboactivate/__init__.py
+++ b/turboactivate/__init__.py
@@ -273,8 +273,6 @@ class TurboActivate(object):
             return True
         except TurboActivateFeaturesChangedError:
             return True
-        except TurboActivateError:
-            return False
 
     # Trial
 


### PR DESCRIPTION
This allows `TurboActivateConnectionDelayedError` and `TurboActivateConnectionError` to bubble up and be handled. We could also just have them both log a warning and `return True`.
